### PR TITLE
Feat/auth 4 rdb

### DIFF
--- a/adapter-in/web/src/main/kotlin/yapp/rating/WebApplication.kt
+++ b/adapter-in/web/src/main/kotlin/yapp/rating/WebApplication.kt
@@ -1,4 +1,4 @@
-package yapp.rating.boardgame
+package yapp.rating
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication

--- a/adapter-out/rdb/build.gradle.kts
+++ b/adapter-out/rdb/build.gradle.kts
@@ -1,10 +1,10 @@
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 plugins {
+    id("org.springframework.boot")
+    id("io.spring.dependency-management")
     kotlin("plugin.spring")
     kotlin("plugin.jpa")
-    kotlin("plugin.allopen")
-    kotlin("plugin.noarg")
 }
 
 allOpen {
@@ -22,9 +22,11 @@ noArg {
 dependencies {
     val springVersion by properties
 
+    api(project(":domain"))
     api(project(":port-out"))
 
     implementation("org.springframework.boot:spring-boot-starter-data-jpa:$springVersion")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
     runtimeOnly("mysql:mysql-connector-java:8.0.33")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test:$springVersion")

--- a/adapter-out/rdb/src/main/kotlin/yapp/rating/AuditingEntity.kt
+++ b/adapter-out/rdb/src/main/kotlin/yapp/rating/AuditingEntity.kt
@@ -1,0 +1,21 @@
+package yapp.rating
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import java.time.LocalDateTime
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class AuditingEntity {
+    @CreatedDate
+    @Column(name = "created_at", updatable = false, nullable = false)
+    var createdDate: LocalDateTime = LocalDateTime.now()
+
+    @LastModifiedDate
+    @Column(name = "modified_at", nullable = false)
+    var modifiedDate: LocalDateTime = LocalDateTime.now()
+}

--- a/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/AuthSocialEntity.kt
+++ b/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/AuthSocialEntity.kt
@@ -1,0 +1,34 @@
+package yapp.rating.auth
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.IdClass
+import jakarta.persistence.Table
+import yapp.rating.AuditingEntity
+
+@Table(name = "auth_social")
+@Entity
+@IdClass(SocialInfo::class)
+class AuthSocialEntity(
+    socialType: SocialType,
+    socialId: String,
+    userId: Long,
+) : AuditingEntity() {
+    @Id
+    @Enumerated(EnumType.STRING)
+    @Column(name = "social_type")
+    var socialType: SocialType = socialType
+        protected set
+
+    @Id
+    @Column(name = "social_id")
+    var socialId: String = socialId
+        protected set
+
+    @Column(name = "user_id")
+    var userId: Long = userId
+        protected set
+}

--- a/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/AuthSocialEntity.kt
+++ b/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/AuthSocialEntity.kt
@@ -12,7 +12,7 @@ import yapp.rating.AuditingEntity
 @Table(name = "auth_social")
 @Entity
 @IdClass(SocialInfo::class)
-class AuthSocialEntity(
+internal class AuthSocialEntity(
     socialType: SocialType,
     socialId: String,
     userId: Long,

--- a/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/AuthSocialRepository.kt
+++ b/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/AuthSocialRepository.kt
@@ -4,4 +4,4 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface AuthSocialRepository : JpaRepository<AuthSocialEntity, SocialInfo>
+internal interface AuthSocialRepository : JpaRepository<AuthSocialEntity, SocialInfo>

--- a/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/AuthSocialRepository.kt
+++ b/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/AuthSocialRepository.kt
@@ -1,0 +1,7 @@
+package yapp.rating.auth
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface AuthSocialRepository : JpaRepository<AuthSocialEntity, SocialInfo>

--- a/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/SocialInfo.kt
+++ b/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/SocialInfo.kt
@@ -1,0 +1,8 @@
+package yapp.rating.auth
+
+import java.io.Serializable
+
+data class SocialInfo(
+    val socialType: SocialType,
+    val socialId: String,
+) : Serializable

--- a/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/SocialType.kt
+++ b/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/SocialType.kt
@@ -1,0 +1,17 @@
+package yapp.rating.auth
+
+import java.lang.UnsupportedOperationException
+
+enum class SocialType {
+    KAKAO,
+    NAVER,
+    GOOGLE,
+}
+
+fun LoginType.toSocialType(): SocialType =
+    when (this) {
+        LoginType.KAKAO -> SocialType.KAKAO
+        LoginType.NAVER -> SocialType.NAVER
+        LoginType.GOOGLE -> SocialType.GOOGLE
+        LoginType.REFRESH -> throw UnsupportedOperationException()
+    }

--- a/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/token/AccessTokenEntity.kt
+++ b/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/token/AccessTokenEntity.kt
@@ -9,7 +9,7 @@ import yapp.rating.AuditingEntity
 
 @Entity
 @Table(name = "auth_access_token")
-class AccessTokenEntity : AuditingEntity() {
+internal class AccessTokenEntity : AuditingEntity() {
     @Id
     @Column(name = "access_token_id")
     var id: Long = 0

--- a/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/token/AccessTokenEntity.kt
+++ b/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/token/AccessTokenEntity.kt
@@ -1,0 +1,29 @@
+package yapp.rating.auth.token
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+import yapp.rating.AuditingEntity
+
+@Entity
+@Table(name = "auth_access_token")
+class AccessTokenEntity : AuditingEntity() {
+    @Id
+    @Column(name = "access_token_id")
+    var id: Long = 0
+        protected set
+
+    @Column(name = "user_id")
+    var userId: Long = 0
+        protected set
+
+    @Column(name = "access_token")
+    lateinit var accessToken: ByteArray
+        protected set
+
+    @Column(name = "expire_at")
+    lateinit var expireAt: LocalDateTime
+        protected set
+}

--- a/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/token/AccessTokenRepository.kt
+++ b/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/token/AccessTokenRepository.kt
@@ -2,4 +2,4 @@ package yapp.rating.auth.token
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface AccessTokenRepository : JpaRepository<AccessTokenEntity, Long>
+internal interface AccessTokenRepository : JpaRepository<AccessTokenEntity, Long>

--- a/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/token/AccessTokenRepository.kt
+++ b/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/token/AccessTokenRepository.kt
@@ -1,0 +1,5 @@
+package yapp.rating.auth.token
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface AccessTokenRepository : JpaRepository<AccessTokenEntity, Long>

--- a/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/token/RefreshTokenEntity.kt
+++ b/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/token/RefreshTokenEntity.kt
@@ -1,0 +1,29 @@
+package yapp.rating.auth.token
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+import yapp.rating.AuditingEntity
+
+@Entity
+@Table(name = "auth_refresh_token")
+class RefreshTokenEntity : AuditingEntity() {
+    @Id
+    @Column(name = "refresh_token_id")
+    var id: Long = 0
+        protected set
+
+    @Column(name = "user_id")
+    var userId: Long = 0
+        protected set
+
+    @Column(name = "refresh_token")
+    lateinit var refreshToken: ByteArray
+        protected set
+
+    @Column(name = "expire_at")
+    lateinit var expireAt: LocalDateTime
+        protected set
+}

--- a/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/token/RefreshTokenEntity.kt
+++ b/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/token/RefreshTokenEntity.kt
@@ -9,7 +9,7 @@ import yapp.rating.AuditingEntity
 
 @Entity
 @Table(name = "auth_refresh_token")
-class RefreshTokenEntity : AuditingEntity() {
+internal class RefreshTokenEntity : AuditingEntity() {
     @Id
     @Column(name = "refresh_token_id")
     var id: Long = 0

--- a/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/token/RefreshTokenRepository.kt
+++ b/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/token/RefreshTokenRepository.kt
@@ -1,0 +1,5 @@
+package yapp.rating.auth.token
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface RefreshTokenRepository : JpaRepository<RefreshTokenEntity, Long>

--- a/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/token/RefreshTokenRepository.kt
+++ b/adapter-out/rdb/src/main/kotlin/yapp/rating/auth/token/RefreshTokenRepository.kt
@@ -2,4 +2,4 @@ package yapp.rating.auth.token
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface RefreshTokenRepository : JpaRepository<RefreshTokenEntity, Long>
+internal interface RefreshTokenRepository : JpaRepository<RefreshTokenEntity, Long>

--- a/adapter-out/rdb/src/main/kotlin/yapp/rating/user/UserEntity.kt
+++ b/adapter-out/rdb/src/main/kotlin/yapp/rating/user/UserEntity.kt
@@ -1,0 +1,29 @@
+package yapp.rating.user
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import yapp.rating.AuditingEntity
+
+@Entity
+@Table(name = "user")
+class UserEntity(
+    name: String,
+) : AuditingEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id", nullable = false)
+    var id: Long = 0
+        protected set
+
+    @Column(name = "name")
+    var name: String = name
+        protected set
+
+    @Column(name = "deleted")
+    var deleted: Boolean = false
+        protected set
+}

--- a/adapter-out/rdb/src/main/kotlin/yapp/rating/user/UserEntity.kt
+++ b/adapter-out/rdb/src/main/kotlin/yapp/rating/user/UserEntity.kt
@@ -10,7 +10,7 @@ import yapp.rating.AuditingEntity
 
 @Entity
 @Table(name = "user")
-class UserEntity(
+internal class UserEntity(
     name: String,
 ) : AuditingEntity() {
     @Id

--- a/adapter-out/rdb/src/main/kotlin/yapp/rating/user/UserRepository.kt
+++ b/adapter-out/rdb/src/main/kotlin/yapp/rating/user/UserRepository.kt
@@ -4,4 +4,4 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface UserRepository : JpaRepository<UserEntity, Long>
+internal interface UserRepository : JpaRepository<UserEntity, Long>

--- a/adapter-out/rdb/src/main/kotlin/yapp/rating/user/UserRepository.kt
+++ b/adapter-out/rdb/src/main/kotlin/yapp/rating/user/UserRepository.kt
@@ -1,0 +1,7 @@
+package yapp.rating.user
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface UserRepository : JpaRepository<UserEntity, Long>

--- a/adapter-out/rdb/src/main/resources/application-rdb.yml
+++ b/adapter-out/rdb/src/main/resources/application-rdb.yml
@@ -19,7 +19,7 @@ spring:
 spring.config.activate.on-profile: local
 spring:
     datasource:
-        url: jdbc:mysql://localhost:3306/team_rating?useUnicode=true&character_set_server=utf8mb4
+        url: jdbc:mysql://localhost:3306/dev?useUnicode=true&character_set_server=utf8mb4
         username: root
         password: 12345678
     jpa:

--- a/adapter-out/rdb/src/main/resources/sql.ddl/2023_05_14_CREATE_AUTH.sql
+++ b/adapter-out/rdb/src/main/resources/sql.ddl/2023_05_14_CREATE_AUTH.sql
@@ -1,0 +1,9 @@
+create table auth_social
+(
+    social_type varchar(10) NOT NULL,
+    social_id   varchar(50) NOT NULL,
+    user_id     bigint      NOT NULL,
+    created_at  datetime    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    modified_at datetime    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY auth_social (social_id, social_type)
+);

--- a/adapter-out/rdb/src/main/resources/sql.ddl/2023_05_14_CREATE_AUTH.sql
+++ b/adapter-out/rdb/src/main/resources/sql.ddl/2023_05_14_CREATE_AUTH.sql
@@ -7,3 +7,27 @@ create table auth_social
     modified_at datetime    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY auth_social (social_id, social_type)
 );
+
+CREATE TABLE auth_access_token
+(
+    access_token_id bigint   NOT NULL AUTO_INCREMENT,
+    access_token    binary(30) NOT NULL,
+    user_id         bigint   NOT NULL,
+    expire_at       DATETIME NOT NULL,
+    create_date     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_date     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY PK_authAccessToken (access_token_id),
+    UNIQUE KEY idx_accesstoken (access_token)
+);
+
+CREATE TABLE auth_refresh_token
+(
+    refresh_token_id bigint   NOT NULL AUTO_INCREMENT,
+    refresh_token    binary(45) NOT NULL,
+    user_id          bigint   NOT NULL,
+    expire_at        DATETIME NOT NULL,
+    create_date      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_date      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY PK_authRefreshToken (refresh_token_id),
+    UNIQUE KEY idx_refreshtoken (refresh_token)
+);

--- a/adapter-out/rdb/src/main/resources/sql.ddl/2023_05_14_CREATE_USER.sql
+++ b/adapter-out/rdb/src/main/resources/sql.ddl/2023_05_14_CREATE_USER.sql
@@ -1,0 +1,9 @@
+create table user
+(
+    user_id     bigint      NOT NULL AUTO_INCREMENT,
+    name        varchar(20) NOT NULL,
+    created_at  datetime    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    modified_at datetime    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    deleted     bit         NOT NULL,
+    PRIMARY KEY PK_user (user_id)
+);

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,8 @@ subprojects {
     dependencies {
         val kotestVersion: String by properties
 
+        implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.15.0")
+
         testImplementation("io.kotest:kotest-runner-junit5-jvm:$kotestVersion")
         testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
         testImplementation("io.mockk:mockk:1.13.5")

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ kotlin.code.style=official
 
 springVersion=3.0.6
 kotestVersion=5.6.1
-kotlinPluginVersion=1.8.21
+kotlinVersion=1.8.21

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,13 +2,13 @@ rootProject.name = "BoardGameRating"
 
 pluginManagement {
     val springVersion: String by settings
-    val kotlinPluginVersion: String by settings
+    val kotlinVersion: String by settings
     plugins {
         id("org.springframework.boot") version springVersion
-        kotlin("plugin.spring") version kotlinPluginVersion
-        kotlin("plugin.jpa") version kotlinPluginVersion
-        kotlin("plugin.allopen") version kotlinPluginVersion
-        kotlin("plugin.noarg") version kotlinPluginVersion
+        kotlin("plugin.spring") version kotlinVersion
+        kotlin("plugin.jpa") version kotlinVersion
+        kotlin("plugin.allopen") version kotlinVersion
+        kotlin("plugin.noarg") version kotlinVersion
     }
 }
 


### PR DESCRIPTION
### Reference
- [Notion Ticket](https://www.notion.so/yapp-workspace/Backend-Auth-DB-f6970d91019a483ca0d2c7eec4dc293c?pvs=4)

sql 파일은 jpa validation을 사용하기에 공유 및 아카이브 목적으로 사용하고자 직접 작성하고 있습니다.
그 외에도 index 이름이 jpa에서 잘 지원되지 않기도 하고
(제가 아는 건 이것뿐이지만 아무튼 그러한 연유로 팀 내에서도 sql을 작성하고 있습니다.)

그 외 굳이 core에 노출 할 필요 없어 보여 (domain 객체를 사용할거라) jpa 관련 클래스도 internal 로 처리했습니다.


### 참고 사항

P1: 꼭 반영해주세요 (Request changes)
P2: 적극적으로 고려해주세요 (Request changes)
P3: 웬만하면 반영해 주세요 (Comment)
P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
P5: 그냥 사소한 의견입니다 (Approve)
