### PR TITLE
sandbox-1: 도커파일 작성

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY . /app_source
 WORKDIR /app_source
 
 RUN chmod +x ./gradlew
+RUN ./gradlew :adapter-in:web:copySwaggerUI
 RUN ./gradlew :adapter-in:web:bootJar
 
 FROM eclipse-temurin:17-jdk-alpine AS RUNNER

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM eclipse-temurin:17-jdk-alpine AS BUILDER
+
+ARG PHASE
+
+RUN mkdir /app_source
+COPY . /app_source
+
+WORKDIR /app_source
+
+RUN chmod +x ./gradlew
+RUN ./gradlew :adapter-in:web:bootJar
+
+FROM eclipse-temurin:17-jdk-alpine AS RUNNER
+
+RUN mkdir /app
+
+COPY --from=BUILDER /app_source/adapter-in/web/build/libs /app
+
+WORKDIR /app
+
+ENV TZ=Asia/Seoul
+
+EXPOSE 8080
+USER nobody
+ENTRYPOINT java \
+  -Dspring.profiles.active=${PHASE:-local} \
+  -jar /app/*.jar

--- a/adapter-in/web/build.gradle.kts
+++ b/adapter-in/web/build.gradle.kts
@@ -29,7 +29,6 @@ tasks {
     withType<BootJar> {
         enabled = true
         mainClass.set("yapp.rating.WebApplicationKt")
-        dependsOn("copySwaggerUI")
     }
 
     val generateSwaggerUIPrefix = "Api"

--- a/adapter-in/web/build.gradle.kts
+++ b/adapter-in/web/build.gradle.kts
@@ -6,6 +6,7 @@ import org.springframework.boot.gradle.tasks.bundling.BootJar
 plugins {
     id("com.epages.restdocs-api-spec") version "0.18.0"
     id("org.hidetake.swagger.generator") version "2.19.2"
+    id("org.springframework.boot")
 }
 
 dependencies {


### PR DESCRIPTION
### Reference
- [Notion Ticket](https://yapp-workspace.notion.site/Back-docker-7147e85a000642079d8435b622dc5433)

도커파일 작성했습니다. 

현재 이미지 빌드는 되는데 컨테이너 실행시 db 커넥션 에러가 나는데요. 
멀티 모듈에서 빌드되는 모듈의 resources 만  포함된다고 하더라구요
web 모듈 기준으로 빌드되기 때문에 rdb 모듈에 있는 application.rdb.yml 가 적용이 안 되어 발생한 문제로 보입니다.
(intelliJ 로 실행할 때는 다른 모듈에 있는 리소스까지 포함된다고 합니다)

테스트는 아래 커맨드로 할 수 있어요
```shell
cd 22nd-Android-Team-2-BE
docker build -t {TAG_NAME} .
```


### 참고 사항

P1: 꼭 반영해주세요 (Request changes)
P2: 적극적으로 고려해주세요 (Request changes)
P3: 웬만하면 반영해 주세요 (Comment)
P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
P5: 그냥 사소한 의견입니다 (Approve)
