### PR TITLE
멤버 닉네임 검사 API 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - 'main'
       - 'dev'
       - 'feat/*'
+      - 'fix/*'
 
 jobs:
   test:

--- a/adapter-in/web/src/test/kotlin/com/yapp/bol/group/member/MemberControllerTest.kt
+++ b/adapter-in/web/src/test/kotlin/com/yapp/bol/group/member/MemberControllerTest.kt
@@ -22,21 +22,32 @@ class MemberControllerTest : ControllerTest() {
     override val controller = MemberController(groupService, memberService)
 
     init {
-        test("GET /v1/group/{groupId}/member/validateNickname") {
+        test("멤버 닉네임 검사") {
+            val groupId = GroupId(1)
+            val nickname = "holden"
+
             every {
                 memberService.validateMemberNickname(any(), any())
             } returns true
 
-            get("/v1/group/1/member/validateNickname?groupId=1&nickname=holden") {}
+            get("/v1/group/{groupId}/member/validateNickname", arrayOf(groupId.value)) {
+                queryParam("nickname", nickname)
+            }
                 .isStatus(200)
                 .makeDocument(
-                    DocumentInfo(identifier = "member", tag = OpenApiTag.MEMBER),
-                    queryParameters(
+                    DocumentInfo(
+                        identifier = "member/{method-name}",
+                        tag = OpenApiTag.MEMBER,
+                        description = "맴버 닉네임 검사"
+                    ),
+                    pathParameters(
                         "groupId" type NUMBER means "그룹 ID",
+                    ),
+                    queryParameters(
                         "nickname" type STRING means "닉네임"
                     ),
                     responseFields(
-                        "isAvailable" type BOOLEAN means "그룹 내에서 닉네임 중복 여부"
+                        "isAvailable" type BOOLEAN means "그룹 내에서 닉네임 사용 가능 여부"
                     )
                 )
         }

--- a/core/src/test/kotlin/com/yapp/bol/group/member/MemberServiceImplTest.kt
+++ b/core/src/test/kotlin/com/yapp/bol/group/member/MemberServiceImplTest.kt
@@ -1,0 +1,57 @@
+package com.yapp.bol.group.member
+
+import com.yapp.bol.auth.UserId
+import com.yapp.bol.group.GroupId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+class MemberServiceImplTest : FunSpec() {
+    private val memberQueryRepository: MemberQueryRepository = mockk()
+    private val memberCommandRepository: MemberCommandRepository = mockk()
+    private val sut = MemberServiceImpl(memberQueryRepository, memberCommandRepository)
+
+    init {
+        context("validateMemberNickname") {
+            val groupId = GroupId(0)
+            val nickname = "닉네임"
+
+            test("Success") {
+                val groupId = GroupId(0)
+                val nickname = "닉네임"
+
+                every { memberQueryRepository.findByNicknameAndGroupId(nickname, groupId) } returns null
+
+                sut.validateMemberNickname(groupId, nickname) shouldBe true
+            }
+
+            test("닉네임 중복") {
+                val mockMember = HostMember(
+                    userId = UserId(0),
+                    nickname = nickname,
+                )
+
+                every { memberQueryRepository.findByNicknameAndGroupId(nickname, groupId) } returns mockMember
+
+                sut.validateMemberNickname(groupId, nickname) shouldBe false
+            }
+
+            test("닉네임 길이 초과") {
+                val nickname = "x".repeat(Member.MAX_NICKNAME_LENGTH + 1)
+
+                every { memberQueryRepository.findByNicknameAndGroupId(nickname, groupId) } returns null
+
+                sut.validateMemberNickname(groupId, nickname) shouldBe false
+            }
+
+            test("닉네임 길이 부족") {
+                val nickname = "x".repeat(Member.MIN_NICKNAME_LENGTH - 1)
+
+                every { memberQueryRepository.findByNicknameAndGroupId(nickname, groupId) } returns null
+
+                sut.validateMemberNickname(groupId, nickname) shouldBe false
+            }
+        }
+    }
+}

--- a/domain/src/main/kotlin/com/yapp/bol/group/member/Member.kt
+++ b/domain/src/main/kotlin/com/yapp/bol/group/member/Member.kt
@@ -21,6 +21,9 @@ abstract class Member internal constructor(
     }
 
     init {
+        if (nickname.length < MIN_NICKNAME_LENGTH) {
+            throw InvalidMemberNicknameException
+        }
         if (nickname.length > MAX_NICKNAME_LENGTH) {
             throw InvalidMemberNicknameException
         }
@@ -32,6 +35,7 @@ abstract class Member internal constructor(
     fun isHost(): Boolean = this is HostMember
 
     companion object {
-        const val MAX_NICKNAME_LENGTH = 6
+        const val MAX_NICKNAME_LENGTH = 10
+        const val MIN_NICKNAME_LENGTH = 1
     }
 }

--- a/domain/src/test/kotlin/com/yapp/bol/member/MemberTest.kt
+++ b/domain/src/test/kotlin/com/yapp/bol/member/MemberTest.kt
@@ -18,8 +18,22 @@ class MemberTest : FunSpec() {
             MEMBER_OWNER.shouldBeInstanceOf<Member>()
         }
 
-        test("멤버 닉네임 길이 제한") {
+        test("멤버 닉네임 최대 길이 제한") {
             val nickname = "x".repeat(Member.MAX_NICKNAME_LENGTH + 1)
+
+            shouldThrow<InvalidMemberNicknameException> {
+                OwnerMember(userId = UserId(0), nickname = nickname)
+            }
+            shouldThrow<InvalidMemberNicknameException> {
+                HostMember(userId = UserId(0), nickname = nickname)
+            }
+            shouldThrow<InvalidMemberNicknameException> {
+                GuestMember(nickname = nickname)
+            }
+        }
+
+        test("멤버 닉네임 최소 길이 제한") {
+            val nickname = "x".repeat(Member.MIN_NICKNAME_LENGTH - 1)
 
             shouldThrow<InvalidMemberNicknameException> {
                 OwnerMember(userId = UserId(0), nickname = nickname)


### PR DESCRIPTION
### Reference
- [Jira Ticket](https://yapp22-aos2.atlassian.net/browse/BOL-)

기존 멤버 닉네임 검사 API 는 중복 체크만 했는데요.
길이 체크도 하게 수정했어요.
스웨거 잘못된 부분도 수정했습니다.
브랜치명을 fix/.. 로 만들어서 ci 도 수정했어요.

+) 요런 수정사항은 지라 티켓을 따야할지 고민이네요...

### 참고 사항

P1: 꼭 반영해주세요 (Request changes)  
P2: 적극적으로 고려해주세요 (Request changes)  
P3: 웬만하면 반영해 주세요 (Comment)  
P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)  
P5: 그냥 사소한 의견입니다 (Approve)  
